### PR TITLE
Support global tools for backwards compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.cs text=auto
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.cs text eol=crlf
+*.cs text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.cs text
+*.cs text=auto

--- a/Jmg.VsixProject/CodeGenerator.cs
+++ b/Jmg.VsixProject/CodeGenerator.cs
@@ -41,11 +41,14 @@ namespace Jmg.VsixProject
 			{
 				var fileInfo = new FileInfo(inputFilePath);
 				fileName = fileInfo.Name;
+
+				// Base name is commonly used to generate the class name
 				baseName = fileName;
 				while (baseName.Contains("."))
 				{
 					baseName = Path.GetFileNameWithoutExtension(baseName);
 				}
+
 				workingDirectory = fileInfo.Directory.FullName;
 			}
 			catch (Exception exc)
@@ -93,9 +96,11 @@ namespace Jmg.VsixProject
 			}
 
 			String toolName;
+			Boolean isGlobalTool;
 			if (spec != null && spec.Files.FirstOrDefault(i => i.FileName == fileName) is Yaml.File file)
 			{
 				toolName = file.Tool;
+				isGlobalTool = false;
 
 				// Set file extension from config
 				if (!(file.Extension is String fileExtension))
@@ -116,6 +121,7 @@ namespace Jmg.VsixProject
 			{
 				// Legacy assumption
 				this.fileExtension = ".cs";
+				isGlobalTool = true;
 			}
 			else
 			{
@@ -128,7 +134,8 @@ namespace Jmg.VsixProject
 				fileNamespace: fileNamespace,
 				toolName: toolName,
 				baseName: baseName,
-				extension: fileExtension
+				extension: fileExtension,
+				runGlobalTool: isGlobalTool
 				);
 
 			return new CodeGenResult(outputFileContent);

--- a/Jmg.VsixProject/DotnetRunner.cs
+++ b/Jmg.VsixProject/DotnetRunner.cs
@@ -11,9 +11,14 @@ namespace Jmg.VsixProject
 	{
 		private const String DotnetExecutableName = "dotnet";
 
-		public static String Run(String fileContents, String workingDirectory, String fileNamespace, String toolName, String baseName, String extension)
+		public static String Run(String fileContents, String workingDirectory, String fileNamespace, String toolName, String baseName, String extension, Boolean runGlobalTool)
 		{
-			var args = $"tool run {toolName} --namespace \"{fileNamespace}\" --name \"{baseName}\" --extension \"{extension}\"";
+			var args = $"{toolName} --namespace \"{fileNamespace}\" --name \"{baseName}\" --extension \"{extension}\"";
+			if (!runGlobalTool)
+			{
+				// Explicitly call local tool
+				args = "tool run " + args;
+			}
 
 			var processStartInfo = new ProcessStartInfo(fileName: DotnetExecutableName, arguments: args)
 			{

--- a/Jmg.VsixProject/Properties/AssemblyInfo.cs
+++ b/Jmg.VsixProject/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Jmg.VsixProject/source.extension.vsixmanifest
+++ b/Jmg.VsixProject/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Jmg.VsixProject.ef3054ed-972c-4ed9-b649-75cd3dd37c2d" Version="1.1" Language="en-US" Publisher="JoeGaggler" />
+        <Identity Id="Jmg.VsixProject.ef3054ed-972c-4ed9-b649-75cd3dd37c2d" Version="1.2" Language="en-US" Publisher="JoeGaggler" />
         <DisplayName>Dotnet Tool Single File Generator</DisplayName>
         <Description xml:space="preserve">Single File Generator for Visual Studio that feeds the source file to a dotnet tool in order to produce the target file.</Description>
     </Metadata>

--- a/Jmg.VsixProject/source.extension.vsixmanifest
+++ b/Jmg.VsixProject/source.extension.vsixmanifest
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-	<Metadata>
-		<Identity Id="Jmg.VsixProject.ef3054ed-972c-4ed9-b649-75cd3dd37c2d" Version="1.0" Language="en-US" Publisher="JoeGaggler" />
-		<DisplayName>Dotnet Tool Single File Generator</DisplayName>
-		<Description xml:space="preserve">Single File Generator for Visual Studio that feeds the source file to a dotnet tool in order to produce the target file.</Description>
-	</Metadata>
-	<Installation>
-		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-	</Installation>
-	<Dependencies>
-		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-	</Dependencies>
-	<Prerequisites>
-		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
-	</Prerequisites>
-	<Assets>
-		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-	</Assets>
+    <Metadata>
+        <Identity Id="Jmg.VsixProject.ef3054ed-972c-4ed9-b649-75cd3dd37c2d" Version="1.1" Language="en-US" Publisher="JoeGaggler" />
+        <DisplayName>Dotnet Tool Single File Generator</DisplayName>
+        <Description xml:space="preserve">Single File Generator for Visual Studio that feeds the source file to a dotnet tool in order to produce the target file.</Description>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
The `dotnet tool run` syntax is only supported for local tools. In order to support existing global tools, we use `dotnet [command]` syntax when running legacy commands.