### PR TITLE
Remove writing document content to standard input

### DIFF
--- a/Jmg.VsixProject/DotnetRunner.cs
+++ b/Jmg.VsixProject/DotnetRunner.cs
@@ -23,7 +23,6 @@ namespace Jmg.VsixProject
 
 			var processStartInfo = new ProcessStartInfo(fileName: DotnetExecutableName, arguments: args)
 			{
-				RedirectStandardInput = true,
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
 				CreateNoWindow = true,
@@ -36,11 +35,6 @@ namespace Jmg.VsixProject
 			processStartInfo.EnvironmentVariables.Add(DotnetNoLogoEnvironmentVariable, "1"); // Disable dotnet welcome messages
 
 			var process = Process.Start(processStartInfo);
-
-			using (var writer = process.StandardInput)
-			{
-				process.StandardInput.Write(fileContents);
-			}
 
 			var outputString = process.StandardOutput.ReadToEnd();
 			var errorString = process.StandardError.ReadToEnd();


### PR DESCRIPTION
Remove writing document content to standard input because it is already ready being read by the tool with the input parameter